### PR TITLE
fix typo in browserslists-config package.json

### DIFF
--- a/planningcenter/browserslist-config/package.json
+++ b/planningcenter/browserslist-config/package.json
@@ -5,9 +5,9 @@
   "author": "Michael Chan <mijoch@gmail.com>",
   "homepage": "https://github.com/planningcenter/design/tree/master/planningcenter/browserslist-config",
   "license": "MIT",
-  "main": "browserlist-config.js",
+  "main": "browserslist-config.js",
   "files": [
-    "browserlist-config.js"
+    "browserslist-config.js"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
When including the shared config in my app, webpack complains:

```
Error: Cannot find module '@planningcenter/browserslist-config'
    at Function.Module._resolveFilename (module.js:548:15)
    at Function.require.resolve (/Users/greg/Code/resources/node_modules/v8-compile-cache/v8-compile-cache.js:162:23)
    at Object.loadQueries (/Users/greg/Code/resources/node_modules/browserslist/node.js:116:35)
    at Function.select (/Users/greg/Code/resources/node_modules/browserslist/index.js:856:26)
    at /Users/greg/Code/resources/node_modules/browserslist/index.js:176:33
    at Array.reduce (<anonymous>)
    at resolve (/Users/greg/Code/resources/node_modules/browserslist/index.js:158:18)
    at browserslist (/Users/greg/Code/resources/node_modules/browserslist/index.js:278:16)
    at postcss$1.plugin.opts (/Users/greg/Code/resources/node_modules/postcss-preset-env/index.js:434:29)
    at creator (/Users/greg/Code/resources/node_modules/postcss/lib/postcss.js:133:35)
    at Object.<anonymous> (/Users/greg/Code/resources/postcss.config.js:5:34)
    at Module._compile (/Users/greg/Code/resources/node_modules/v8-compile-cache/v8-compile-cache.js:178:30)
    at requireFromString (/Users/greg/Code/resources/node_modules/require-from-string/index.js:28:4)
    at parseJsFile (/Users/greg/Code/resources/node_modules/postcss-load-config/node_modules/cosmiconfig/dist/loadJs.js:15:15)
    at <anonymous>
```

It looks like there's a typo in `package.json` that's affecting resolution (although the typo version is the way I always say it too 😂).