### PR TITLE
Fix React warnings in development

### DIFF
--- a/planningcenter/topbar/modules/color_app_icon.tsx
+++ b/planningcenter/topbar/modules/color_app_icon.tsx
@@ -17,11 +17,11 @@ export function ColorAppIcon({
       viewBox="0 0 20 20"
       style={{ display: "block" }}
     >
-      {ColorAppSquircles[appName] ? ColorAppSquircles[appName]() : <span />}
+      {ColorAppSquircles[appName] ? ColorAppSquircles[appName]() : <span key="key1" />}
       {AppSymbols[appName] ? (
-        React.createElement(AppSymbols[appName], { color: "#fff" })
+        React.createElement(AppSymbols[appName], { color: "#fff", key: "key2"})
       ) : (
-        <div>appName not supported</div>
+        <div key="key3">appName not supported</div>
       )}
     </svg>
   );

--- a/planningcenter/topbar/modules/color_app_squircles.tsx
+++ b/planningcenter/topbar/modules/color_app_squircles.tsx
@@ -180,8 +180,8 @@ export function Publishing(): JSX.Element[] {
         y2="17.958"
         gradientUnits="userSpaceOnUse"
       >
-        <stop offset="0" stop-color="#787882" />
-        <stop offset="1" stop-color="#5f5f69" />
+        <stop offset="0" stopColor="#787882" />
+        <stop offset="1" stopColor="#5f5f69" />
       </linearGradient>
       <linearGradient
         id="linear-gradient-2"


### PR DESCRIPTION
React was issuing two warnings with the latest version of topbar:

1. Warning: Invalid DOM property `stop-color`. Did you mean `stopColor`?
2. Warning: Each child in a list should have a unique "key" prop.

Following the stack traces, these appeared to be the correct solutions.