### PR TITLE
feat(Avatar): add srcset prop

### DIFF
--- a/planningcenter/avatar/src/avatar.js
+++ b/planningcenter/avatar/src/avatar.js
@@ -9,11 +9,12 @@ export function Avatar({
   as: As = "span",
   className,
   src,
+  srcSet,
   alt,
   children,
   ...props
 }) {
-  let imgProps = { src, alt };
+  let imgProps = { src, srcSet, alt };
   let img = <img {...imgProps} />;
 
   return (


### PR DESCRIPTION
adds the `srcSet` prop to `imgProps` to allow for image src swapping on high-density displays

_before:_
![before](https://user-images.githubusercontent.com/20110616/64980624-cfc8cb80-d87f-11e9-91ad-cc5c09fc0d45.jpg)

_after:_
![after](https://user-images.githubusercontent.com/20110616/64981024-c7bd5b80-d880-11e9-805f-248778b69479.jpg)


**implementation details:**
- The `srcset` spec [[link]](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images#Resolution_switching_Same_size_different_resolutions) takes a comma-delimited list of image src paths followed by the pixel-density/size at which the image source will be replaced. There could have been a better way to include the already declared `src` prop as the first item in the list to avoid repeating code but I decided to leave the `srcSet` prop as a "returns whatever you give it" prop to avoid confusion in the component API structure. 
- There is also the option to declare completely different images based on the browser's size [[link]](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images#Resolution_switching_Different_sizesl) (which shouldn't be a consideration with our specific use of Avatars) but it felt strange to limit the component's ability to generate a flexible `srcset` attribute. 