### PR TITLE
feat(topbar): update logout link

### DIFF
--- a/planningcenter/topbar/modules/medium_topbar.tsx
+++ b/planningcenter/topbar/modules/medium_topbar.tsx
@@ -466,7 +466,7 @@ export class Topbar extends React.Component<
 
             <HoverableListItem
               component="a"
-              href={`${pcoUrl(this.props.env)("accounts")}/logout`}
+              href={`${pcoUrl(this.props.env)("login")}/logout`}
               onClick={() => {
                 this.props.requestClearAppsCache();
                 this.props.requestClearConnectedPeopleCache();

--- a/planningcenter/topbar/modules/not_small_topbar.tsx
+++ b/planningcenter/topbar/modules/not_small_topbar.tsx
@@ -737,7 +737,7 @@ export class Topbar extends React.Component<
 
             <HoverableListItem
               component="a"
-              href={`${pcoUrl(this.props.env)("accounts")}/logout`}
+              href={`${pcoUrl(this.props.env)("login")}/logout`}
               onClick={() => {
                 this.props.requestClearAppsCache();
                 this.props.requestClearConnectedPeopleCache();

--- a/planningcenter/topbar/modules/small_topbar.tsx
+++ b/planningcenter/topbar/modules/small_topbar.tsx
@@ -446,7 +446,7 @@ export class Topbar extends React.Component<
 
                   <div style={{ ...IEFlex1 }}>
                     <a
-                      href={`${pcoUrl(this.props.env)("accounts")}/logout`}
+                      href={`${pcoUrl(this.props.env)("login")}/logout`}
                       onClick={() => {
                         this.props.requestClearAppsCache();
                         this.props.requestClearConnectedPeopleCache();


### PR DESCRIPTION
Now that all login/password reset actions are being handled by `Login`, this PR updates the "Log out" link  in the account switcher dropdown from `accounts` to `login`