### PR TITLE
feat(topbar): add referer query string

### DIFF
--- a/planningcenter/topbar/CHANGELOG.md
+++ b/planningcenter/topbar/CHANGELOG.md
@@ -14,6 +14,7 @@
   - `@types/react`: `^16.14.2` => `^17.0.0`
   - `@types/react-dom`: `^16.9.10` => `^17.0.0`
 - Unlock modern builds by removing `--format cjs` flag for improved bundling app-side
+- Add `referer` query parameter to `AppSwitch` urls: [Accounts PR](https://github.com/ministrycentered/accounts/pull/1910)
 
 # 6.1.0 (prerelease)
 

--- a/planningcenter/topbar/modules/getAppsSwitchProductPath.tsx
+++ b/planningcenter/topbar/modules/getAppsSwitchProductPath.tsx
@@ -1,0 +1,13 @@
+export default function getProductSwitchProductUrl(
+  productName: string
+): string {
+  let basePath = `/apps/${productName.toLowerCase()}`;
+  let referer = window?.location.toString();
+
+  if (!referer) return basePath;
+
+  let params = new URLSearchParams();
+  params.append("referer", referer);
+
+  return `${basePath}?${params.toString()}`;
+}

--- a/planningcenter/topbar/modules/medium_topbar.tsx
+++ b/planningcenter/topbar/modules/medium_topbar.tsx
@@ -520,9 +520,10 @@ export class Topbar extends React.Component<
   }
 }
 
-export const Route = ({ active, style, name = "", ...props }) => (
+export const Route = ({ active, href, style, name = "", ...props }) => (
   <HoverableListItem
     component="a"
+    href={`${href}?referer=${location.pathname}`}
     style={{
       paddingLeft: "16px",
       paddingRight: "16px",

--- a/planningcenter/topbar/modules/medium_topbar.tsx
+++ b/planningcenter/topbar/modules/medium_topbar.tsx
@@ -520,10 +520,9 @@ export class Topbar extends React.Component<
   }
 }
 
-export const Route = ({ active, href, style, name = "", ...props }) => (
+export const Route = ({ active, style, name = "", ...props }) => (
   <HoverableListItem
     component="a"
-    href={`${href}?referer=${location.pathname}`}
     style={{
       paddingLeft: "16px",
       paddingRight: "16px",

--- a/planningcenter/topbar/modules/not_small_topbar.tsx
+++ b/planningcenter/topbar/modules/not_small_topbar.tsx
@@ -851,7 +851,7 @@ export class Route extends React.Component<
   }
 
   render() {
-    const { active, colors, style = null, ...nativeProps } = this.props;
+    const { active, colors, href, style = null, ...nativeProps } = this.props;
 
     const getBackgroundColor = () => {
       if (this.state.entered && this.state.down) return colors.base2;
@@ -861,6 +861,7 @@ export class Route extends React.Component<
 
     return (
       <a
+        href={`${href}?referer=${location.pathname}`}
         style={{
           lineHeight: "32px",
           marginRight: "4px", // off-grid

--- a/planningcenter/topbar/modules/not_small_topbar.tsx
+++ b/planningcenter/topbar/modules/not_small_topbar.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import pcoUrl from "./pco_url";
+import getAppsSwitchProductPath from "./getAppsSwitchProductPath";
 import { StyledRoot } from "./styled_root";
 import { Unbutton } from "./unbutton";
 import { Avatar } from "./avatar";
@@ -230,9 +231,9 @@ export const AppsMenu = (props) => (
                 ...(i && { borderTop: "1px solid #ddd" }),
               }}
               key={name}
-              href={`${pcoUrl(props.env)(
-                "accounts"
-              )}/apps/${name.toLowerCase()}?referer=${location.pathname}`}
+              href={
+                pcoUrl(props.env)("accounts") + getAppsSwitchProductPath(name)
+              }
               data-turbolinks={false}
             >
               <ColorAppIcon appName={name.replace(/[\s-]/, "")} size={24} />

--- a/planningcenter/topbar/modules/not_small_topbar.tsx
+++ b/planningcenter/topbar/modules/not_small_topbar.tsx
@@ -232,7 +232,7 @@ export const AppsMenu = (props) => (
               key={name}
               href={`${pcoUrl(props.env)(
                 "accounts"
-              )}/apps/${name.toLowerCase()}`}
+              )}/apps/${name.toLowerCase()}?referer=${location.pathname}`}
               data-turbolinks={false}
             >
               <ColorAppIcon appName={name.replace(/[\s-]/, "")} size={24} />
@@ -851,7 +851,7 @@ export class Route extends React.Component<
   }
 
   render() {
-    const { active, colors, href, style = null, ...nativeProps } = this.props;
+    const { active, colors, style = null, ...nativeProps } = this.props;
 
     const getBackgroundColor = () => {
       if (this.state.entered && this.state.down) return colors.base2;
@@ -861,7 +861,6 @@ export class Route extends React.Component<
 
     return (
       <a
-        href={`${href}?referer=${location.pathname}`}
         style={{
           lineHeight: "32px",
           marginRight: "4px", // off-grid

--- a/planningcenter/topbar/modules/small_topbar.tsx
+++ b/planningcenter/topbar/modules/small_topbar.tsx
@@ -131,7 +131,7 @@ export class Topbar extends React.Component<
                 : {
                     routesMenuVisible: false,
                     userMenuVisible: true,
-                  },
+                  }
             );
           }}
         >
@@ -289,13 +289,13 @@ export class Topbar extends React.Component<
                             }}
                             data-turbolinks={false}
                             href={`${pcoUrl(this.props.env)(
-                              "accounts",
+                              "accounts"
                             )}/apps/${name.toLowerCase()}`}
                           >
                             <UserMenuAppLockup appName={name} />
                           </a>
                         </li>
-                      ),
+                      )
                     )}
                   </ul>
                   <div
@@ -356,7 +356,7 @@ export class Topbar extends React.Component<
                           }}
                         >
                           {connectedPeopleMenuFormatter(
-                            this.props.connectedPeople,
+                            this.props.connectedPeople
                           ).map(({ id, attributes: person }) => (
                             <li key={id}>
                               <a
@@ -487,7 +487,7 @@ export class Topbar extends React.Component<
                 : {
                     routesMenuVisible: true,
                     userMenuVisible: false,
-                  },
+                  }
             )
           }
         >
@@ -508,8 +508,9 @@ export class Topbar extends React.Component<
   }
 }
 
-export const Route = ({ active, ...props }) => (
+export const Route = ({ active, href, ...props }) => (
   <a
+    href={`${href}?referer=${location.pathname}`}
     style={{
       display: "block",
       backgroundColor: "#444",

--- a/planningcenter/topbar/modules/small_topbar.tsx
+++ b/planningcenter/topbar/modules/small_topbar.tsx
@@ -131,7 +131,7 @@ export class Topbar extends React.Component<
                 : {
                     routesMenuVisible: false,
                     userMenuVisible: true,
-                  }
+                  },
             );
           }}
         >
@@ -289,13 +289,13 @@ export class Topbar extends React.Component<
                             }}
                             data-turbolinks={false}
                             href={`${pcoUrl(this.props.env)(
-                              "accounts"
+                              "accounts",
                             )}/apps/${name.toLowerCase()}`}
                           >
                             <UserMenuAppLockup appName={name} />
                           </a>
                         </li>
-                      )
+                      ),
                     )}
                   </ul>
                   <div
@@ -356,7 +356,7 @@ export class Topbar extends React.Component<
                           }}
                         >
                           {connectedPeopleMenuFormatter(
-                            this.props.connectedPeople
+                            this.props.connectedPeople,
                           ).map(({ id, attributes: person }) => (
                             <li key={id}>
                               <a
@@ -487,7 +487,7 @@ export class Topbar extends React.Component<
                 : {
                     routesMenuVisible: true,
                     userMenuVisible: false,
-                  }
+                  },
             )
           }
         >
@@ -508,9 +508,8 @@ export class Topbar extends React.Component<
   }
 }
 
-export const Route = ({ active, href, ...props }) => (
+export const Route = ({ active, ...props }) => (
   <a
-    href={`${href}?referer=${location.pathname}`}
     style={{
       display: "block",
       backgroundColor: "#444",

--- a/planningcenter/topbar/modules/small_topbar.tsx
+++ b/planningcenter/topbar/modules/small_topbar.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import pcoUrl from "./pco_url";
+import getAppsSwitchProductPath from "./getAppsSwitchProductPath";
 import { StyledRoot } from "./styled_root";
 import { Unbutton } from "./unbutton";
 import { Avatar } from "./avatar";
@@ -131,7 +132,7 @@ export class Topbar extends React.Component<
                 : {
                     routesMenuVisible: false,
                     userMenuVisible: true,
-                  },
+                  }
             );
           }}
         >
@@ -288,14 +289,15 @@ export class Topbar extends React.Component<
                               paddingRight: "16px",
                             }}
                             data-turbolinks={false}
-                            href={`${pcoUrl(this.props.env)(
-                              "accounts",
-                            )}/apps/${name.toLowerCase()}`}
+                            href={
+                              pcoUrl(this.props.env)("accounts") +
+                              getAppsSwitchProductPath(name)
+                            }
                           >
                             <UserMenuAppLockup appName={name} />
                           </a>
                         </li>
-                      ),
+                      )
                     )}
                   </ul>
                   <div
@@ -356,7 +358,7 @@ export class Topbar extends React.Component<
                           }}
                         >
                           {connectedPeopleMenuFormatter(
-                            this.props.connectedPeople,
+                            this.props.connectedPeople
                           ).map(({ id, attributes: person }) => (
                             <li key={id}>
                               <a
@@ -487,7 +489,7 @@ export class Topbar extends React.Component<
                 : {
                     routesMenuVisible: true,
                     userMenuVisible: false,
-                  },
+                  }
             )
           }
         >


### PR DESCRIPTION
Adds a referer query string to each `Route` component so Accounts can use this to direct people to the respective product's profile page, even in browsers like Brave that require altering settings to get this functionality.