### PR TITLE
docs(elements): add additional way of importing in JavaScript

### DIFF
--- a/planningcenter/elements/README.md
+++ b/planningcenter/elements/README.md
@@ -20,5 +20,6 @@ Add it.
 Install it.
 
 - Webpack `import "@planningcenter/elements"`
+- Other JavaScript Bundlers `import "@planningcenter/elements/dist/elements.css"`
 - Sprockets `/*= require @planningcenter/elements */`
 - Sass `@import "@planningcenter/elements"`

--- a/planningcenter/elements/__instructions.stories.mdx
+++ b/planningcenter/elements/__instructions.stories.mdx
@@ -23,6 +23,7 @@ Add it.
 Install it.
 
 - Webpack `import "@planningcenter/elements"`
+- Other JavaScript Bundlers `import "@planningcenter/elements/dist/elements.css"`
 - Sprockets `/*= require @planningcenter/elements */`
 - Sass `@import "@planningcenter/elements"`
 - HTML `<link rel="stylesheet" href="path/to/@planningcenter/elements.css">`


### PR DESCRIPTION
For whatever reason, other ways of bundling (Babel in this case) require importing directly from the source. This adds that additional way just in case it comes up for someone else.