### PR TITLE
Set preformatted-content image height to auto

### DIFF
--- a/churchcenter/preformatted-content/index.css
+++ b/churchcenter/preformatted-content/index.css
@@ -41,6 +41,7 @@
 }
 
 [data-preformatted-content] img {
+  height: var(--image--height, auto);
   max-width: var(--image--max-width, 100%);
   border-radius: var(--image--border-radius, 3px);
 }


### PR DESCRIPTION
Issue: Content editors will sometimes inline the image height and width (`height="1080" width="1080"`). When these values are present, our `max-width` will override the image width, but we have nothing overriding the image height, and thus the images get distorted. Adding a default of `auto` to the image height resolves the issue.