### PR TITLE
Doxy Updates

### DIFF
--- a/churchcenter/doxy-elements/doxy-elements.stories.mdx
+++ b/churchcenter/doxy-elements/doxy-elements.stories.mdx
@@ -133,25 +133,30 @@ export function SampleColorLayout(props) {
   );
 }
 
-export function Color({ bgColor, color, ...props }) {
+export function Color({ bgColor, color, colorName, colorHsl, ...props }) {
   return (
     <div
       style={{
-        backgroundColor: bgColor,
-        alignItems: "center",
+        backgroundColor: `var(${bgColor})`,
         borderRadius: 8,
-        color: color,
+        color: `var(${color})`,
         display: "flex",
+        flexDirection: "column",
         fontSize: 14,
         fontWeight: 500,
-        height: 40,
-        justifyContent: "center",
+        justifyContent: "space-between",
         margin: "0.5rem",
         padding: "1rem",
-        flex: 1,
+        flexBasis: "calc(25% - 3rem)",
       }}
       {...props}
-    />
+    >
+      <div>
+        <strong>{colorName}</strong>
+        <div style={{ paddingTop: 4 }}>HSL({colorHsl})</div>
+      </div>
+      <div style={{ paddingTop: "1rem" }}>{bgColor}</div>
+    </div>
   );
 }
 
@@ -159,202 +164,208 @@ export function Color({ bgColor, color, ...props }) {
   <Story name="color">
     <>
       <div
-        data-color-scheme="dark"
-        data-contrast="low"
-        style={{ padding: "1rem" }}
-      >
-        <SampleColorLayout>
-          <Color
-            bgColor="var(--unstable-monochrome-shade-0)"
-            color="var(--unstable-monochrome-shade-10)"
-          >
-            0
-          </Color>
-          <Color
-            bgColor="var(--unstable-monochrome-shade-1)"
-            color="var(--unstable-monochrome-shade-10)"
-          >
-            1
-          </Color>
-          <Color
-            bgColor="var(--unstable-monochrome-shade-2)"
-            color="var(--unstable-monochrome-shade-10)"
-          >
-            2
-          </Color>
-          <Color
-            bgColor="var(--unstable-monochrome-shade-3)"
-            color="var(--unstable-monochrome-shade-10)"
-          >
-            3
-          </Color>
-          <Color
-            bgColor="var(--unstable-monochrome-shade-4)"
-            color="var(--unstable-monochrome-shade-0)"
-          >
-            4
-          </Color>
-          <Color
-            bgColor="var(--unstable-monochrome-shade-5)"
-            color="var(--unstable-monochrome-shade-0)"
-          >
-            5
-          </Color>
-          <Color
-            bgColor="var(--unstable-monochrome-shade-6)"
-            color="var(--unstable-monochrome-shade-0)"
-          >
-            6
-          </Color>
-          <Color
-            bgColor="var(--unstable-monochrome-shade-7)"
-            color="var(--unstable-monochrome-shade-0)"
-          >
-            7
-          </Color>
-          <Color
-            bgColor="var(--unstable-monochrome-shade-8)"
-            color="var(--unstable-monochrome-shade-0)"
-          >
-            8
-          </Color>
-          <Color
-            bgColor="var(--unstable-monochrome-shade-9)"
-            color="var(--unstable-monochrome-shade-0)"
-          >
-            9
-          </Color>
-          <Color
-            bgColor="var(--unstable-monochrome-shade-10)"
-            color="var(--unstable-monochrome-shade-0)"
-          >
-            10
-          </Color>
-          <div style={{ display: "flex", width: "100%" }}>
-            <Color
-              bgColor="var(--color-topaz)"
-              color="var(--unstable-monochrome-shade-0)"
-            >
-              Topaz
-            </Color>
-            <Color
-              bgColor="var(--color-turquoise)"
-              color="var(--unstable-monochrome-shade-0)"
-            >
-              Turquoise
-            </Color>
-            <Color
-              bgColor="var(--color-emerald)"
-              color="var(--unstable-monochrome-shade-0)"
-            >
-              Emerald
-            </Color>
-            <Color
-              bgColor="var(--color-ruby)"
-              color="var(--unstable-monochrome-shade-0)"
-            >
-              Ruby
-            </Color>
-          </div>
-        </SampleColorLayout>
-      </div>
-      <div
         data-color-scheme="light"
         data-contrast="low"
         style={{ padding: "1rem" }}
       >
         <SampleColorLayout>
           <Color
-            bgColor="var(--unstable-monochrome-shade-0)"
-            color="var(--unstable-monochrome-shade-10)"
-          >
-            0
-          </Color>
+            bgColor="--color-tint10"
+            color="--color-tint0"
+            colorName="Static Gray 12"
+            colorHsl="0, 0%, 12%"
+          />
           <Color
-            bgColor="var(--unstable-monochrome-shade-1)"
-            color="var(--unstable-monochrome-shade-10)"
-          >
-            1
-          </Color>
+            bgColor="--color-tint9"
+            color="--color-tint0"
+            colorName="Static Gray 24"
+            colorHsl="0, 0%, 24%"
+          />
           <Color
-            bgColor="var(--unstable-monochrome-shade-2)"
-            color="var(--unstable-monochrome-shade-10)"
-          >
-            2
-          </Color>
+            bgColor="--color-tint8"
+            color="--color-tint0"
+            colorName="Static Gray 45"
+            colorHsl="0, 0%, 45%"
+          />
           <Color
-            bgColor="var(--unstable-monochrome-shade-3)"
-            color="var(--unstable-monochrome-shade-10)"
-          >
-            3
-          </Color>
+            bgColor="--color-tint7"
+            color="--color-tint0"
+            colorName="Static Gray 62"
+            colorHsl="0, 0%, 62%"
+          />
           <Color
-            bgColor="var(--unstable-monochrome-shade-4)"
-            color="var(--unstable-monochrome-shade-0)"
-          >
-            4
-          </Color>
+            bgColor="--color-tint6"
+            color="--color-tint10"
+            colorName="Static Gray 81"
+            colorHsl="0, 0%, 81%"
+          />
           <Color
-            bgColor="var(--unstable-monochrome-shade-5)"
-            color="var(--unstable-monochrome-shade-0)"
-          >
-            5
-          </Color>
+            bgColor="--color-tint5"
+            color="--color-tint10"
+            colorName="Static Gray 88"
+            colorHsl="0, 0%, 88%"
+          />
           <Color
-            bgColor="var(--unstable-monochrome-shade-6)"
-            color="var(--unstable-monochrome-shade-0)"
-          >
-            6
-          </Color>
+            bgColor="--color-tint4"
+            color="--color-tint10"
+            colorName="Static Gray 93"
+            colorHsl="0, 0%, 93%"
+          />
           <Color
-            bgColor="var(--unstable-monochrome-shade-7)"
-            color="var(--unstable-monochrome-shade-0)"
-          >
-            7
-          </Color>
+            bgColor="--color-tint3"
+            color="--color-tint10"
+            colorName="Static Gray 95"
+            colorHsl="0, 0%, 95%"
+          />
           <Color
-            bgColor="var(--unstable-monochrome-shade-8)"
-            color="var(--unstable-monochrome-shade-0)"
-          >
-            8
-          </Color>
+            bgColor="--color-tint2"
+            color="--color-tint10"
+            colorName="Static Gray 97"
+            colorHsl="0, 0%, 97%"
+          />
           <Color
-            bgColor="var(--unstable-monochrome-shade-9)"
-            color="var(--unstable-monochrome-shade-0)"
-          >
-            9
-          </Color>
+            bgColor="--color-tint1"
+            color="--color-tint10"
+            colorName="Static Gray 98"
+            colorHsl="0, 0%, 98%"
+          />
           <Color
-            bgColor="var(--unstable-monochrome-shade-10)"
-            color="var(--unstable-monochrome-shade-0)"
-          >
-            10
-          </Color>
+            bgColor="--color-tint0"
+            color="--color-tint10"
+            colorName="Static Gray 100"
+            colorHsl="0, 0%, 100%"
+          />
           <div style={{ display: "flex", width: "100%" }}>
             <Color
-              bgColor="var(--color-topaz)"
-              color="var(--unstable-monochrome-shade-10)"
-            >
-              Topaz
-            </Color>
+              bgColor="--color-topaz"
+              color="--color-tint10"
+              colorName="Topaz"
+              colorHsl="207, 90%, 61%"
+            />
             <Color
-              bgColor="var(--color-turquoise)"
-              color="var(--unstable-monochrome-shade-10)"
-            >
-              Turquoise
-            </Color>
+              bgColor="--color-turquoise"
+              color="--color-tint10"
+              colorName="Turquoise"
+              colorHsl="174, 42%, 51%"
+            />
             <Color
-              bgColor="var(--color-emerald)"
-              color="var(--unstable-monochrome-shade-10)"
-            >
-              Emerald
-            </Color>
+              bgColor="--color-emerald"
+              color="--color-tint10"
+              colorName="Emerald"
+              colorHsl="122, 38%, 57%"
+            />
             <Color
-              bgColor="var(--color-ruby)"
-              color="var(--unstable-monochrome-shade-10)"
-            >
-              Ruby
-            </Color>
+              bgColor="--color-ruby"
+              color="--color-tint10"
+              colorName="Ruby"
+              colorHsl="1, 83%, 62%"
+            />
+            <Color
+              bgColor="--color-citrine"
+              color="--color-tint10"
+              colorName="Citrine"
+              colorHsl="42, 90%, 60%"
+            />
+          </div>
+        </SampleColorLayout>
+      </div>
+      <div
+        data-color-scheme="dark"
+        data-contrast="low"
+        style={{ padding: "1rem" }}
+      >
+        <SampleColorLayout>
+          <Color
+            bgColor="--color-tint10"
+            color="--color-tint0"
+            colorName="Static Gray 98"
+            colorHsl="0, 0%, 98%"
+          />
+          <Color
+            bgColor="--color-tint9"
+            color="--color-tint0"
+            colorName="Static Gray 88"
+            colorHsl="0, 0%, 88%"
+          />
+          <Color
+            bgColor="--color-tint8"
+            color="--color-tint0"
+            colorName="Static Gray 68"
+            colorHsl="0, 0%, 68%"
+          />
+          <Color
+            bgColor="--color-tint7"
+            color="--color-tint0"
+            colorName="Static Gray 50"
+            colorHsl="0, 0%, 50%"
+          />
+          <Color
+            bgColor="--color-tint6"
+            color="--color-tint10"
+            colorName="Static Gray 32"
+            colorHsl="0, 0%, 32%"
+          />
+          <Color
+            bgColor="--color-tint5"
+            color="--color-tint10"
+            colorName="Static Gray 24"
+            colorHsl="0, 0%, 24%"
+          />
+          <Color
+            bgColor="--color-tint4"
+            color="--color-tint10"
+            colorName="Static Gray 19"
+            colorHsl="0, 0%, 19%"
+          />
+          <Color
+            bgColor="--color-tint3"
+            color="--color-tint10"
+            colorName="Static Gray 17"
+            colorHsl="0, 0%, 17%"
+          />
+          <Color
+            bgColor="--color-tint2"
+            color="--color-tint10"
+            colorName="Static Gray 15"
+            colorHsl="0, 0%, 15%"
+          />
+          <Color
+            bgColor="--color-tint1"
+            color="--color-tint10"
+            colorName="Static Gray 12"
+            colorHsl="0, 0%, 12%"
+          />
+          <Color
+            bgColor="--color-tint0"
+            color="--color-tint10"
+            colorName="Static Gray 7"
+            colorHsl="0, 0%, 7%"
+          />
+          <div style={{ display: "flex", width: "100%" }}>
+            <Color
+              bgColor="--color-topaz"
+              color="--color-tint10"
+              colorName="Topaz Dark"
+              colorHsl="207, 90%, 51%"
+            />
+            <Color
+              bgColor="--color-turquoise"
+              color="--color-tint10"
+              colorName="Turquoise Dark"
+              colorHsl="172, 52%, 41%"
+            />
+            <Color
+              bgColor="--color-emerald"
+              color="--color-tint10"
+              colorName="Emerald Dark"
+              colorHsl="122, 48%, 57%"
+            />
+            <Color
+              bgColor="--color-ruby"
+              color="--color-tint10"
+              colorName="Ruby Dark"
+              colorHsl="1, 75%, 55%"
+            />
           </div>
         </SampleColorLayout>
       </div>

--- a/churchcenter/doxy-elements/doxy-elements.stories.mdx
+++ b/churchcenter/doxy-elements/doxy-elements.stories.mdx
@@ -579,6 +579,75 @@ export function SampleFormLayout({ style, ...props }) {
   </Story>
 </Preview>
 
+### Notice
+
+<Preview>
+  <Story name="notice">
+    <>
+      <div
+        data-color-scheme="dark"
+        data-contrast="low"
+        style={{ 
+          padding: "1rem",
+          "--box--border-radius": "4px",
+          "--box--padding": "1rem",
+          "--box--margin": "0"
+          }}
+      >
+        <div data-notice="alt:warning" data-box>
+          Just letting you know, you should stir the kool-aid before you serve it.
+        </div>
+      </div>
+      <div
+        data-color-scheme="light"
+        data-contrast="low"
+        style={{ 
+          padding: "1rem 1rem 0 1rem",
+          "--box--border-radius": "4px",
+          "--box--padding": "1rem",
+          "--box--margin": "0 0 1rem 0"
+          }}
+      >
+        <div data-notice data-box>
+          You have a form to fill out.
+        </div>
+        <div data-notice="alt:info" data-box>
+          You have a form to fill out.
+        </div>
+        <div data-notice="alt:positive" data-box>
+          Preferences saved
+        </div>
+        <div data-notice="alt:negative" data-box>
+          Your form has errors and could not be submitted.
+        </div>
+        <div data-notice="alt:warning" data-box>
+          Just letting you know, you should stir the kool-aid before you serve it.
+        </div>
+      </div>
+    </>
+  </Story>
+</Preview>
+
+#### Notice: size
+
+<Preview>
+  <Story name="notice:size">
+    <div
+        data-color-scheme="light"
+        data-contrast="low"
+        style={{ 
+          padding: "1rem",
+          "--box--border-radius": "4px",
+          "--box--padding": "0.5rem",
+          }}
+      >
+      <span data-notice="size:small" data-box>
+        Size: small
+      </span>
+    </div>
+  </Story>
+</Preview>
+
 ### Surface
 
 export function SampleSurfaceLayout({ style, ...props }) {

--- a/churchcenter/doxy-elements/doxy-elements.stories.mdx
+++ b/churchcenter/doxy-elements/doxy-elements.stories.mdx
@@ -11,7 +11,9 @@ export function SampleBadgeLayout(props) {
     <div
       style={{
         display: "flex",
-        "--box--margin": "0 0.5rem 0.5rem 0",
+        "--box--margin": "0 0.5rem 0 0",
+        "--box--padding": "0 6px",
+        "--box--border-radius": "4px",
         padding: "1rem",
       }}
       {...props}
@@ -58,7 +60,13 @@ export function SampleBadgeLayout(props) {
 
 <Preview>
   <Story name="badge:size">
-    <SampleBadgeLayout>
+    <SampleBadgeLayout 
+      data-color-scheme="light" 
+      data-contrast="low" 
+      style={{ 
+        "--box--padding": "0 6px", 
+        "--box--border-radius": "3px"
+      }}>
       <span data-badge="size:small" data-box>
         Size: small
       </span>

--- a/churchcenter/doxy-elements/doxy-elements.stories.mdx
+++ b/churchcenter/doxy-elements/doxy-elements.stories.mdx
@@ -164,6 +164,106 @@ export function Color({ bgColor, color, colorName, colorHsl, ...props }) {
   <Story name="color">
     <>
       <div
+        data-color-scheme="dark"
+        data-contrast="low"
+        style={{ padding: "1rem" }}
+      >
+        <SampleColorLayout>
+          <Color
+            bgColor="--color-tint10"
+            color="--color-tint0"
+            colorName="Static Gray 98"
+            colorHsl="0, 0%, 98%"
+          />
+          <Color
+            bgColor="--color-tint9"
+            color="--color-tint0"
+            colorName="Static Gray 88"
+            colorHsl="0, 0%, 88%"
+          />
+          <Color
+            bgColor="--color-tint8"
+            color="--color-tint0"
+            colorName="Static Gray 68"
+            colorHsl="0, 0%, 68%"
+          />
+          <Color
+            bgColor="--color-tint7"
+            color="--color-tint0"
+            colorName="Static Gray 50"
+            colorHsl="0, 0%, 50%"
+          />
+          <Color
+            bgColor="--color-tint6"
+            color="--color-tint10"
+            colorName="Static Gray 32"
+            colorHsl="0, 0%, 32%"
+          />
+          <Color
+            bgColor="--color-tint5"
+            color="--color-tint10"
+            colorName="Static Gray 24"
+            colorHsl="0, 0%, 24%"
+          />
+          <Color
+            bgColor="--color-tint4"
+            color="--color-tint10"
+            colorName="Static Gray 19"
+            colorHsl="0, 0%, 19%"
+          />
+          <Color
+            bgColor="--color-tint3"
+            color="--color-tint10"
+            colorName="Static Gray 17"
+            colorHsl="0, 0%, 17%"
+          />
+          <Color
+            bgColor="--color-tint2"
+            color="--color-tint10"
+            colorName="Static Gray 15"
+            colorHsl="0, 0%, 15%"
+          />
+          <Color
+            bgColor="--color-tint1"
+            color="--color-tint10"
+            colorName="Static Gray 12"
+            colorHsl="0, 0%, 12%"
+          />
+          <Color
+            bgColor="--color-tint0"
+            color="--color-tint10"
+            colorName="Static Gray 7"
+            colorHsl="0, 0%, 7%"
+          />
+          <div style={{ display: "flex", width: "100%" }}>
+            <Color
+              bgColor="--color-topaz"
+              color="--color-tint10"
+              colorName="Topaz Dark"
+              colorHsl="207, 90%, 51%"
+            />
+            <Color
+              bgColor="--color-turquoise"
+              color="--color-tint10"
+              colorName="Turquoise Dark"
+              colorHsl="172, 52%, 41%"
+            />
+            <Color
+              bgColor="--color-emerald"
+              color="--color-tint10"
+              colorName="Emerald Dark"
+              colorHsl="122, 48%, 57%"
+            />
+            <Color
+              bgColor="--color-ruby"
+              color="--color-tint10"
+              colorName="Ruby Dark"
+              colorHsl="1, 75%, 55%"
+            />
+          </div>
+        </SampleColorLayout>
+      </div>
+      <div
         data-color-scheme="light"
         data-contrast="low"
         style={{ padding: "1rem" }}
@@ -265,106 +365,6 @@ export function Color({ bgColor, color, colorName, colorHsl, ...props }) {
               color="--color-tint10"
               colorName="Citrine"
               colorHsl="42, 90%, 60%"
-            />
-          </div>
-        </SampleColorLayout>
-      </div>
-      <div
-        data-color-scheme="dark"
-        data-contrast="low"
-        style={{ padding: "1rem" }}
-      >
-        <SampleColorLayout>
-          <Color
-            bgColor="--color-tint10"
-            color="--color-tint0"
-            colorName="Static Gray 98"
-            colorHsl="0, 0%, 98%"
-          />
-          <Color
-            bgColor="--color-tint9"
-            color="--color-tint0"
-            colorName="Static Gray 88"
-            colorHsl="0, 0%, 88%"
-          />
-          <Color
-            bgColor="--color-tint8"
-            color="--color-tint0"
-            colorName="Static Gray 68"
-            colorHsl="0, 0%, 68%"
-          />
-          <Color
-            bgColor="--color-tint7"
-            color="--color-tint0"
-            colorName="Static Gray 50"
-            colorHsl="0, 0%, 50%"
-          />
-          <Color
-            bgColor="--color-tint6"
-            color="--color-tint10"
-            colorName="Static Gray 32"
-            colorHsl="0, 0%, 32%"
-          />
-          <Color
-            bgColor="--color-tint5"
-            color="--color-tint10"
-            colorName="Static Gray 24"
-            colorHsl="0, 0%, 24%"
-          />
-          <Color
-            bgColor="--color-tint4"
-            color="--color-tint10"
-            colorName="Static Gray 19"
-            colorHsl="0, 0%, 19%"
-          />
-          <Color
-            bgColor="--color-tint3"
-            color="--color-tint10"
-            colorName="Static Gray 17"
-            colorHsl="0, 0%, 17%"
-          />
-          <Color
-            bgColor="--color-tint2"
-            color="--color-tint10"
-            colorName="Static Gray 15"
-            colorHsl="0, 0%, 15%"
-          />
-          <Color
-            bgColor="--color-tint1"
-            color="--color-tint10"
-            colorName="Static Gray 12"
-            colorHsl="0, 0%, 12%"
-          />
-          <Color
-            bgColor="--color-tint0"
-            color="--color-tint10"
-            colorName="Static Gray 7"
-            colorHsl="0, 0%, 7%"
-          />
-          <div style={{ display: "flex", width: "100%" }}>
-            <Color
-              bgColor="--color-topaz"
-              color="--color-tint10"
-              colorName="Topaz Dark"
-              colorHsl="207, 90%, 51%"
-            />
-            <Color
-              bgColor="--color-turquoise"
-              color="--color-tint10"
-              colorName="Turquoise Dark"
-              colorHsl="172, 52%, 41%"
-            />
-            <Color
-              bgColor="--color-emerald"
-              color="--color-tint10"
-              colorName="Emerald Dark"
-              colorHsl="122, 48%, 57%"
-            />
-            <Color
-              bgColor="--color-ruby"
-              color="--color-tint10"
-              colorName="Ruby Dark"
-              colorHsl="1, 75%, 55%"
             />
           </div>
         </SampleColorLayout>

--- a/churchcenter/doxy-elements/index.css
+++ b/churchcenter/doxy-elements/index.css
@@ -4,6 +4,7 @@
 @import "./modules/button.css";
 @import "./modules/heading.css";
 @import "./modules/media-card.css";
+@import "./modules/notice.css";
 @import "./modules/select.css";
 @import "./modules/text.css";
 @import "./modules/text-input.css";

--- a/churchcenter/doxy-elements/modules/badge.css
+++ b/churchcenter/doxy-elements/modules/badge.css
@@ -1,33 +1,44 @@
 [data-badge] {
-  background-color: var(--badge--background-color, hsl(0, 0%, 90%));
-  color: var(--badge--color, hsl(0, 0%, 30%));
+  background-color: var(--badge--background-color, var(--color-tint5));
+  color: var(--badge--color, var(--color-tint8));
   border-radius: var(--badge--border-radius, 4px);
   display: var(--badge--display, inline-block);
   font-size: var(--badge--font-size, 0.75rem);
-  line-height: var(--badge--line-height, 1.25rem);
-  padding: var(--badge--padding, 0 8px);
+  line-height: var(--badge--line-height, 1.5rem);
+  padding: var(--badge--padding, 0 6px);
   white-space: var(--badge--white-space, nowrap);
 }
 
-:root {
-  --badge--padding: var(--badge--padding, 0 8px);
-}
+:root {}
 
 [data-color-scheme="light"] [data-badge~="alt:negative"] {
   --badge--background-color: hsl(0, 79%, 96%);
-  --badge--color: #d51713;
+  --badge--color: hsl(1, 84%, 45%);
 }
 [data-color-scheme="light"] [data-badge~="alt:positive"] {
   --badge--background-color: hsl(120, 36%, 96%);
-  --badge--color: #3a813d;
+  --badge--color: hsl(123, 38%, 37%);
 }
 [data-color-scheme="light"] [data-badge~="alt:warning"] {
   --badge--background-color: hsl(39, 89%, 96%);
-  --badge--color: #916607;
+  --badge--color: hsl(41, 91%, 30%);
+}
+
+[data-color-scheme="dark"] [data-badge~="alt:negative"] {
+  --badge--color: hsl(0, 79%, 96%);
+  --badge--background-color: hsl(1, 84%, 45%);
+}
+[data-color-scheme="dark"] [data-badge~="alt:positive"] {
+  --badge--color: hsl(120, 36%, 96%);
+  --badge--background-color: hsl(123, 38%, 37%);
+}
+[data-color-scheme="dark"] [data-badge~="alt:warning"] {
+  --badge--color: hsl(39, 89%, 96%);
+  --badge--background-color: hsl(41, 91%, 30%);
 }
 
 [data-badge~="size:small"] {
   --badge--border-radius: 3px;
   --badge--font-size: 0.6875rem;
-  --badge--line-height: 1rem;
+  --badge--line-height: 1.25rem;
 }

--- a/churchcenter/doxy-elements/modules/button.css
+++ b/churchcenter/doxy-elements/modules/button.css
@@ -95,7 +95,7 @@ a[data-button] {
 }
 
 [data-button~="action:default"][data-button~="variant:text-only"] {
-  --button--color: var(--unstable-monochrome-shade-2);
+  --button--color: var(--color-tint8);
 }
 
 [data-button~="action:destroy"][data-button~="variant:text-only"] {

--- a/churchcenter/doxy-elements/modules/color-scheme_dark.css
+++ b/churchcenter/doxy-elements/modules/color-scheme_dark.css
@@ -1,32 +1,40 @@
 /* color system */
 [data-color-scheme="dark"][data-contrast="low"] {
-  --color-topaz: #128ef3;
-  --color-turquoise: #329f95;
-  --color-emerald: #5dc660;
-  --color-ruby: #e23936;
+  --color-topaz: hsl(207, 90%, 51%);
+  --color-turquoise: hsl(172, 52%, 41%);
+  --color-emerald: hsl(122, 48%, 57%);
+  --color-ruby: hsl(1, 75%, 55%);
 
-  --unstable-monochrome-shade-0: hsl(0, 0%, 98%);
-  --unstable-monochrome-shade-1: hsl(0, 0%, 88%);
-  --unstable-monochrome-shade-2: hsl(0, 0%, 68%);
-  --unstable-monochrome-shade-3: hsl(0, 0%, 50%);
-  --unstable-monochrome-shade-4: hsl(0, 0%, 32%);
-  --unstable-monochrome-shade-5: hsl(0, 0%, 24%);
-  --unstable-monochrome-shade-6: hsl(0, 0%, 19%);
-  --unstable-monochrome-shade-7: hsl(0, 0%, 17%);
-  --unstable-monochrome-shade-8: hsl(0, 0%, 15%);
-  --unstable-monochrome-shade-9: hsl(0, 0%, 12%);
-  --unstable-monochrome-shade-10: hsl(0, 0%, 7%);
+  --color-tint10: hsl(0, 0%, 98%);
+  --color-tint9: hsl(0, 0%, 88%);
+  --color-tint8: hsl(0, 0%, 68%);
+  --color-tint7: hsl(0, 0%, 50%);
+  --color-tint6: hsl(0, 0%, 32%);
+  --color-tint5: hsl(0, 0%, 24%);
+  --color-tint4: hsl(0, 0%, 19%);
+  --color-tint3: hsl(0, 0%, 17%);
+  --color-tint2: hsl(0, 0%, 15%);
+  --color-tint1: hsl(0, 0%, 12%);
+  --color-tint0: hsl(0, 0%, 7%);
 }
 
 /* theme-specific elements */
 [data-color-scheme="dark"][data-contrast="low"] {
-  background-color: hsl(0, 0%, 7%);
-  color: hsl(0, 0%, 98%);
+  background-color: var(--color-tint0);
+  color: var(--color-tint10);
 
-  --badge--background-color: var(--unstable-monochrome-shade-2);
-  --badge--color: var(--unstable-monochrome-shade-8);
+  --badge--background-color: var(--color-tint8);
+  --badge--color: var(--color-tint2);
 
-  --button--outline-variant--background-image: linear-gradient(var(--unstable-monochrome-shade-9), var(--unstable-monochrome-shade-9)), linear-gradient(135deg, var(--color-turquoise) 0%, var(--color-emerald) 100%);
+  --button--outline-variant--background-image: linear-gradient(
+      var(--color-tint1),
+      var(--color-tint1)
+    ),
+    linear-gradient(
+      135deg,
+      var(--color-turquoise) 0%,
+      var(--color-emerald) 100%
+    );
 
   --select--background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='-7 -7  30 30' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M7.55504 10.5092C7.75343 10.7608 8.13399 10.7635 8.33592 10.5147L11.3385 6.81508C11.6037 6.48828 11.3711 6 10.9503 6H5.03091C4.61331 6 4.37972 6.48163 4.63826 6.80956L7.55504 10.5092Z' fill='%23CFCFCF'/%3E%3C/svg%3E%0A");
 }

--- a/churchcenter/doxy-elements/modules/color-scheme_light.css
+++ b/churchcenter/doxy-elements/modules/color-scheme_light.css
@@ -1,32 +1,40 @@
 /* color system */
 [data-color-scheme="light"][data-contrast="low"] {
-  --color-topaz: #42a5f5;
-  --color-turquoise: #4db6ac;
-  --color-emerald: #66bb6a;
-  --color-ruby: #ef5350;
+  --color-topaz: hsl(207, 90%, 61%);
+  --color-turquoise: hsl(174, 42%, 51%);
+  --color-tourmaline: hsl(174, 60%, 38%);
+  --color-emerald: hsl(122, 38%, 57%);
+  --color-ruby: hsl(1, 83%, 62%);
+  --color-citrine: hsl(42, 90%, 60%);
+  --color-marigold: var(--color-citrine);
 
-  --unstable-monochrome-shade-0: hsl(0, 0%, 12%);
-  --unstable-monochrome-shade-1: hsl(0, 0%, 24%);
-  --unstable-monochrome-shade-2: hsl(0, 0%, 45%);
-  --unstable-monochrome-shade-3: hsl(0, 0%, 62%);
-  --unstable-monochrome-shade-4: hsl(0, 0%, 81%);
-  --unstable-monochrome-shade-5: hsl(0, 0%, 88%);
-  --unstable-monochrome-shade-6: hsl(0, 0%, 93%);
-  --unstable-monochrome-shade-7: hsl(0, 0%, 95%);
-  --unstable-monochrome-shade-8: hsl(0, 0%, 97%);
-  --unstable-monochrome-shade-9: hsl(0, 0%, 98%);
-  --unstable-monochrome-shade-10: hsl(0, 0%, 100%);
+  --color-tint10: hsl(0, 0%, 12%);
+  --color-tint9: hsl(0, 0%, 24%);
+  --color-tint8: hsl(0, 0%, 45%);
+  --color-tint7: hsl(0, 0%, 62%);
+  --color-tint6: hsl(0, 0%, 81%);
+  --color-tint5: hsl(0, 0%, 88%);
+  --color-tint4: hsl(0, 0%, 93%);
+  --color-tint3: hsl(0, 0%, 95%);
+  --color-tint2: hsl(0, 0%, 97%);
+  --color-tint1: hsl(0, 0%, 98%);
+  --color-tint0: hsl(0, 0%, 100%);
 }
 
 /* theme-specific elements */
 [data-color-scheme="light"][data-contrast="low"] {
-  background-color: hsl(0, 0%, 100%);
-  color: hsl(0, 0%, 26%);
+  background-color: var(--color-tint0);
+  color: var(--color-tint9);
 
-  --badge--background-color: var(--unstable-monochrome-shade-7);
-  --badge--color: var(--unstable-monochrome-shade-2);
+  --badge--background-color: var(--color-tint3);
+  --badge--color: var(--color-tint8);
 
-  --button--outline-variant--background-image: linear-gradient(white, white), linear-gradient(135deg, var(--color-turquoise) 0%, var(--color-emerald) 100%);
+  --button--outline-variant--background-image: linear-gradient(white, white),
+    linear-gradient(
+      135deg,
+      var(--color-turquoise) 0%,
+      var(--color-emerald) 100%
+    );
 
   --select--background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='-7 -7  30 30' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M7.55504 10.5092C7.75343 10.7608 8.13399 10.7635 8.33592 10.5147L11.3385 6.81508C11.6037 6.48828 11.3711 6 10.9503 6H5.03091C4.61331 6 4.37972 6.48163 4.63826 6.80956L7.55504 10.5092Z' fill='%23737373'/%3E%3C/svg%3E%0A");
 }

--- a/churchcenter/doxy-elements/modules/color-scheme_universal.css
+++ b/churchcenter/doxy-elements/modules/color-scheme_universal.css
@@ -3,25 +3,26 @@ html {
 }
 
 [data-color-scheme] {
-  --surface-1of1--background-color: var(--unstable-monochrome-shade-10);
+  --surface-1of1--background-color: var(--color-tint0);
 
-  --surface-1of2--background-color: var(--unstable-monochrome-shade-8);
-  --surface-2of2--background-color: var(--unstable-monochrome-shade-10);
+  --surface-1of2--background-color: var(--color-tint2);
+  --surface-2of2--background-color: var(--color-tint0);
 
-  --text--color: var(--unstable-monochrome-shade-1);
+  --text--color: var(--color-tint9);
 
-  --heading--color: var(--unstable-monochrome-shade-0);
-  --heading-5--color: var(--unstable-monochrome-shade-3);
+  --heading--color: var(--color-tint10);
+  --heading-5--color: var(--color-tint7);
 
-  --definition-term--color: var(--unstable-monochrome-shade-3);
-  --definition--color: var(--unstable-monochrome-shade-1);
+  --definition-term--color: var(--color-tint7);
+  --definition--color: var(--color-tint9);
 
-  --text-input--border-color: var(--unstable-monochrome-shade-4);
+  --text-input--border-color: var(--color-tint6);
 
   --text-input--outline_focus: #d3eafd;
-  --text-input--box-shadow: inset 0 1px 2px var(--unstable-monochrome-shade-8);
+  --text-input--box-shadow: inset 0 1px 2px var(--color-tint2);
   --text-input--box-shadow_focus: 0px 0px 3px 0 #a3d3fa;
 
-  --select--border-color: var(--unstable-monochrome-shade-4);
-  --button--outline-variant--background-image: linear-gradient(white, white), linear-gradient(black, black);
+  --select--border-color: var(--color-tint6);
+  --button--outline-variant--background-image: linear-gradient(white, white),
+    linear-gradient(black, black);
 }

--- a/churchcenter/doxy-elements/modules/notice.css
+++ b/churchcenter/doxy-elements/modules/notice.css
@@ -10,7 +10,7 @@
 :root {}
 
 [data-color-scheme="light"] [data-notice~="alt:info"] {
-  --notice--background-color: hsl(207deg 90% 96%);
+  --notice--background-color: hsl(207, 90%, 96%);
 }
 [data-color-scheme="light"] [data-notice~="alt:negative"] {
   --notice--background-color: hsla(1, 83%, 62%, 0.10);

--- a/churchcenter/doxy-elements/modules/notice.css
+++ b/churchcenter/doxy-elements/modules/notice.css
@@ -1,0 +1,28 @@
+[data-notice] {
+  background-color: var(--notice--background-color, var(--color-tint2));
+  color: var(--notice--color, var(--color-tint9));
+  border-radius: var(--notice--border-radius, 4px);
+  font-size: var(--notice--font-size, 0.875rem);
+  padding: var(--notice--padding, 0 16px);
+  line-height: var(--notice--line-height, 1.25);
+}
+
+:root {}
+
+[data-color-scheme="light"] [data-notice~="alt:info"] {
+  --notice--background-color: hsl(207deg 90% 96%);
+}
+[data-color-scheme="light"] [data-notice~="alt:negative"] {
+  --notice--background-color: hsla(1, 83%, 62%, 0.10);
+}
+[data-color-scheme="light"] [data-notice~="alt:positive"] {
+  --notice--background-color: hsl(120, 36%, 96%);
+}
+[data-color-scheme="light"] [data-notice~="alt:warning"] {
+  --notice--background-color: hsl(39, 89%, 96%);
+}
+
+[data-notice~="size:small"] {
+  --notice--font-size: 0.75rem;
+  --notice--padding: 0.5rem;
+}

--- a/churchcenter/doxy-elements/package-lock.json
+++ b/churchcenter/doxy-elements/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@churchcenter/doxy-elements",
-  "version": "0.0.10-alpha.0",
+  "version": "0.0.12-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/churchcenter/doxy-elements/package-lock.json
+++ b/churchcenter/doxy-elements/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@churchcenter/doxy-elements",
-  "version": "0.0.9",
+  "version": "0.0.10-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/churchcenter/doxy-elements/package-lock.json
+++ b/churchcenter/doxy-elements/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@churchcenter/doxy-elements",
-  "version": "0.0.12-alpha.0",
+  "version": "0.0.12-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/churchcenter/doxy-elements/package-lock.json
+++ b/churchcenter/doxy-elements/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@churchcenter/doxy-elements",
-  "version": "0.0.12-alpha.1",
+  "version": "0.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/churchcenter/doxy-elements/package.json
+++ b/churchcenter/doxy-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@churchcenter/doxy-elements",
-  "version": "0.0.12-alpha.0",
+  "version": "0.0.12-alpha.1",
   "description": "Doxy system applied to @planningcenter/elements",
   "style": "dist/doxy-elements.css",
   "files": [

--- a/churchcenter/doxy-elements/package.json
+++ b/churchcenter/doxy-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@churchcenter/doxy-elements",
-  "version": "0.0.10-alpha.0",
+  "version": "0.0.12-alpha.0",
   "description": "Doxy system applied to @planningcenter/elements",
   "style": "dist/doxy-elements.css",
   "files": [

--- a/churchcenter/doxy-elements/package.json
+++ b/churchcenter/doxy-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@churchcenter/doxy-elements",
-  "version": "0.0.12-alpha.1",
+  "version": "0.0.12",
   "description": "Doxy system applied to @planningcenter/elements",
   "style": "dist/doxy-elements.css",
   "files": [

--- a/churchcenter/doxy-elements/package.json
+++ b/churchcenter/doxy-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@churchcenter/doxy-elements",
-  "version": "0.0.9",
+  "version": "0.0.10-alpha.0",
   "description": "Doxy system applied to @planningcenter/elements",
   "style": "dist/doxy-elements.css",
   "files": [

--- a/planningcenter/elements/package-lock.json
+++ b/planningcenter/elements/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@planningcenter/elements",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/planningcenter/elements/package.json
+++ b/planningcenter/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planningcenter/elements",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Shared Planning Center element styles",
   "style": "dist/elements.css",
   "files": [

--- a/planningcenter/grids/package-lock.json
+++ b/planningcenter/grids/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@planningcenter/grids",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/planningcenter/grids/package.json
+++ b/planningcenter/grids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planningcenter/grids",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Shared Planning Center Grids",
   "style": "dist/grids.css",
   "files": [


### PR DESCRIPTION
We've been using the `--unstable-monochrome-shade-#` var names for some time, and they no longer feel unstable. They've been renamed to `--color-tint#` and are in use in all Church Center products, including Church Center Javascript Navigation.

Added `notice` docs and vars.

### Documentation updates
- color scale
- badges
- notice