### PR TITLE
feat(topbar): add ability to override text color

### DIFF
--- a/planningcenter/topbar/modules/not_small_topbar.tsx
+++ b/planningcenter/topbar/modules/not_small_topbar.tsx
@@ -460,6 +460,10 @@ export class Topbar extends React.Component<
     return this.setState({ routesVisible: true });
   }
 
+  getTextColor() {
+    return this.props.colors.text || "#fff";
+  }
+
   render() {
     const ProfileContainer = ({ component, href, ...nativeProps }) =>
       this.props.linkToProfile ? (
@@ -537,7 +541,7 @@ export class Topbar extends React.Component<
               lineHeight: "32px",
               fontSize: "13px",
               borderRadius: "9999px",
-              color: "white",
+              color: this.getTextColor(),
               backgroundColor: this.props.colors.base1,
               display: "flex",
               ...slightBackgroundTransition,
@@ -860,6 +864,10 @@ export class Route extends React.Component<
       return "transparent";
     };
 
+    const getTextColor = () => {
+      return colors.text || "#fff";
+    }
+
     return (
       <a
         style={{
@@ -870,7 +878,7 @@ export class Route extends React.Component<
           paddingLeft: "12px",
           paddingRight: "12px",
           fontSize: "14px",
-          color: "white",
+          color: getTextColor(),
           fontWeight: 600,
           textDecoration: "none",
           textTransform: "capitalize",


### PR DESCRIPTION
In order for Giving to have better topbar text contrast, we need the ability to provide an overridable `text` color prop

[More details/screenshots here](https://trello.com/c/tjzAsV8P/4842-make-giving-topbar-text-accessible)