### PR TITLE
🐛 Preformatted content links are assigned the wrong custom property

### DIFF
--- a/churchcenter/preformatted-content/index.css
+++ b/churchcenter/preformatted-content/index.css
@@ -34,7 +34,7 @@
 
 [data-preformatted-content] a {
   font-weight: var(--link--font-weight, 600);
-  text-decoration: var(--link--font-weight, none);
+  text-decoration: var(--link--text-decoration, none);
 }
 
 [data-preformatted-content] blockquote {

--- a/churchcenter/preformatted-content/package.json
+++ b/churchcenter/preformatted-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@churchcenter/preformatted-content",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Shared styles for uncontrolled, user formatted content",
   "style": "dist/preformatted-content.css",
   "files": [


### PR DESCRIPTION
Looks like a typo snuck in and we were applying `—link—font-weight` for the `text-decoration` property. 

Fixed here!